### PR TITLE
Compatibility with mapboxgl 0.54.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ var map = new mapboxgl.Map({
 });
 
 map.on("style.load", function () {
-	map.addControl(new mapboxgl.Minimap());
+	map.addControl(new mapboxgl.Minimap(), 'top-right'); // Possible values are bottom-left, bottom-right, top-left, top-right
 });
 ```
 
@@ -28,22 +28,22 @@ Options:
 	id: "mapboxgl-minimap",
 	position: "bottom-left",
 	width: "320px",
-	height: "181px",
+	height: "180px",
 	style: "mapbox://styles/mapbox/streets-v8",
 	center: [0, 0],
-
 	zoom: 6,
-	zoomAdjust: null, // should be a function; will be bound to Minimap
+
+	// should be a function; will be bound to Minimap
+	zoomAdjust: null,
+
+	// if parent map zoom >= 18 and minimap zoom >= 14, set minimap zoom to 16
 	zoomLevels: [
-		// if parent map zoom >= 18 and minimap zoom >= 14, set minimap zoom to 16
 		[18, 14, 16],
 		[16, 12, 14],
 		[14, 10, 12],
 		[12, 8, 10],
 		[10, 6, 8]
 	],
-
-	maxBounds: null, // Do not set or set as https://docs.mapbox.com/mapbox-gl-js/api/#lnglatboundslike
 
 	lineColor: "#08F",
 	lineWidth: 1,
@@ -53,6 +53,11 @@ Options:
 	fillOpacity: 0.25,
 
 	dragPan: false,
-	scrollZoom: false
+	scrollZoom: false,
+	boxZoom: false,
+	dragRotate: false,
+	keyboard: false,
+	doubleClickZoom: false,
+	touchZoomRotate: false
 }
 ```

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Options:
 		[12, 8, 10],
 		[10, 6, 8]
 	],
-	
-	bounds: "parent", // or a valid lngLat object/array
+
+	maxBounds: null, // Do not set or set as https://docs.mapbox.com/mapbox-gl-js/api/#lnglatboundslike
 
 	lineColor: "#08F",
 	lineWidth: 1,

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Mapbox GL Minimap Control
 
+## Demo
 [Demo on GitHub pages](http://aesqe.github.io/mapboxgl-minimap/)
 
 **--- work in progress; overall performance can probably be improved ---**
 
----
+## How to use it
 
 ```javascript
 var map = new mapboxgl.Map({
@@ -19,14 +20,11 @@ map.on("style.load", function () {
 });
 ```
 
----
-
-Options:
+## Options
 
 ```javascript
 {
 	id: "mapboxgl-minimap",
-	position: "bottom-left",
 	width: "320px",
 	height: "180px",
 	style: "mapbox://styles/mapbox/streets-v8",
@@ -61,3 +59,7 @@ Options:
 	touchZoomRotate: false
 }
 ```
+
+## Compatibility
+
+The latest version should be compatible with maboxgl 0.54.0

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
 	<meta charset="utf-8">
 	<title>Mapbox GL Minimap</title>
-	<link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v0.18.0/mapbox-gl.css">
+	<link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v0.54.0/mapbox-gl.css">
 </head>
 <body>
 
 	<div id="map" style="width: 1280px; height: 720px;"></div>
 
-	<script type="text/javascript" src="https://api.mapbox.com/mapbox-gl-js/v0.18.0/mapbox-gl.js"></script>
+	<script type="text/javascript" src="https://api.mapbox.com/mapbox-gl-js/v0.54.0/mapbox-gl.js"></script>
 	<script type="text/javascript" src="mapboxgl-control-minimap.js"></script>
 	<script type="text/javascript">
 
@@ -27,6 +27,6 @@
 		});
 
 	</script>
-	
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
 			map.addControl(new mapboxgl.Minimap({
         center: [-73.94656812952897, 40.72912351406106],
         zoom: 6,
-        zoomLevels: [],
-      }));
+        zoomLevels: []
+      }), 'top-right');
 		});
 
 	</script>

--- a/index.html
+++ b/index.html
@@ -19,11 +19,15 @@
 			container: "map",
 			style: "mapbox://styles/mapbox/streets-v8",
 			center: [-73.94656812952897, 40.72912351406106],
-			zoom: 7
+			zoom: 10
 		});
 
 		map.on("load", function () {
-			map.addControl(new mapboxgl.Minimap());
+			map.addControl(new mapboxgl.Minimap({
+        center: [-73.94656812952897, 40.72912351406106],
+        zoom: 6,
+        zoomLevels: [],
+      }));
 		});
 
 	</script>

--- a/mapboxgl-control-minimap.js
+++ b/mapboxgl-control-minimap.js
@@ -306,6 +306,8 @@ Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 		container.setAttribute('style', 'width: ' + opts.width + '; height: ' + opts.height + ';');
 		container.addEventListener("contextmenu", this._preventDefault);
 
+		parentMap.getContainer().appendChild(container);
+
 		if( opts.id !== "" ) {
 			container.id = opts.id;
 		}

--- a/mapboxgl-control-minimap.js
+++ b/mapboxgl-control-minimap.js
@@ -16,7 +16,6 @@ Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 
 	options: {
 		id: "mapboxgl-minimap",
-		position: "bottom-left",
 		width: "320px",
 		height: "180px",
 		style: "mapbox://styles/mapbox/streets-v8",
@@ -306,8 +305,6 @@ Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 		container.className = "mapboxgl-ctrl-minimap";
 		container.setAttribute('style', 'width: ' + opts.width + '; height: ' + opts.height + ';');
 		container.addEventListener("contextmenu", this._preventDefault);
-
-		parentMap.getContainer().appendChild(container);
 
 		if( opts.id !== "" ) {
 			container.id = opts.id;

--- a/mapboxgl-control-minimap.js
+++ b/mapboxgl-control-minimap.js
@@ -64,7 +64,7 @@ Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 			center: opts.center
 		});
 
-		if (opts.maxBounds) mapboxgl.setMaxBounds(opts.maxBounds);
+		if (opts.maxBounds) miniMap.setMaxBounds(opts.maxBounds);
 
 		miniMap.on("load", this._load.bind(this));
 

--- a/mapboxgl-control-minimap.js
+++ b/mapboxgl-control-minimap.js
@@ -67,6 +67,8 @@ Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 			center: opts.center
 		});
 
+		if (opts.maxBounds) mapboxgl.setMaxBounds(opts.maxBounds);
+		
 		miniMap.on("load", this._load.bind(this));
 
 		return this._container;

--- a/mapboxgl-control-minimap.js
+++ b/mapboxgl-control-minimap.js
@@ -142,11 +142,11 @@ Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 		parentMap.on("move", this._update.bind(this));
 
 		miniMap.on("mousemove", this._mouseMove.bind(this));
-		miniMap.on("mousedown", this._mouseDown.bind(this), true);
+		miniMap.on("mousedown", this._mouseDown.bind(this));
 		miniMap.on("mouseup", this._mouseUp.bind(this));
 
 		miniMap.on("touchmove", this._mouseMove.bind(this));
-		miniMap.on("touchstart", this._mouseDown.bind(this), true);
+		miniMap.on("touchstart", this._mouseDown.bind(this));
 		miniMap.on("touchend", this._mouseUp.bind(this));
 
 		this._miniMapCanvas = miniMap.getCanvasContainer();

--- a/mapboxgl-control-minimap.js
+++ b/mapboxgl-control-minimap.js
@@ -35,8 +35,6 @@ Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 			[10, 6, 8]
 		],
 
-		bounds: "parent",
-
 		lineColor: "#08F",
 		lineWidth: 1,
 		lineOpacity: 1,
@@ -68,7 +66,7 @@ Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 		});
 
 		if (opts.maxBounds) mapboxgl.setMaxBounds(opts.maxBounds);
-		
+
 		miniMap.on("load", this._load.bind(this));
 
 		return this._container;
@@ -94,14 +92,6 @@ Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 			this.options.zoomAdjust = opts.zoomAdjust.bind(this);
 		} else if( opts.zoomAdjust === null ) {
 			this.options.zoomAdjust = this._zoomAdjust.bind(this);
-		}
-
-		if( opts.bounds === "parent" ) {
-			opts.bounds = parentMap.getBounds();
-		}
-
-		if( typeof opts.bounds === "object" ) {
-			miniMap.fitBounds(opts.bounds, {duration: 50});
 		}
 
 		var bounds = miniMap.getBounds();

--- a/mapboxgl-control-minimap.js
+++ b/mapboxgl-control-minimap.js
@@ -302,7 +302,7 @@ Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 		var opts = this.options;
 		var container = document.createElement("div");
 
-		container.className = "mapboxgl-ctrl-minimap";
+		container.className = "mapboxgl-ctrl-minimap mapboxgl-ctrl";
 		container.setAttribute('style', 'width: ' + opts.width + '; height: ' + opts.height + ';');
 		container.addEventListener("contextmenu", this._preventDefault);
 

--- a/mapboxgl-control-minimap.js
+++ b/mapboxgl-control-minimap.js
@@ -1,6 +1,6 @@
 function Minimap ( options )
 {
-	mapboxgl.util.setOptions(this, options);
+	Object.assign(this.options, options);
 
 	this._ticking = false;
 	this._lastMouseMoveEvent = null;
@@ -12,7 +12,7 @@ function Minimap ( options )
 	this._trackingRectCoordinates = [[[], [], [], [], []]];
 }
 
-Minimap.prototype = mapboxgl.util.inherit(mapboxgl.Control, {
+Minimap.prototype = Object.assign({}, mapboxgl.NavigationControl.prototype, {
 
 	options: {
 		id: "mapboxgl-minimap",


### PR DESCRIPTION
This PR makes the minimap compatible with a higher version of mapboxgl (0.54.0). 

Changes:

- Change unsupported maboxgl.util for Object.assign methods
- Add maxBounds setting to minimap if provided in the options
- Remove the logic around `bounds: parent`: on load, the minimap would get the bounds of his parent, the tracking rect would then be the entire size of the minimap. Was there a valid reason why this code was there?
- In the example, changed mapbox version from 0.18.0 to 0.54.0 and added/moved relevant options
- Update README
